### PR TITLE
Fixed chapter/verse/markers transcription mistakes in Ps 76-150

### DIFF
--- a/Moffat/19-Psalms.usfm
+++ b/Moffat/19-Psalms.usfm
@@ -4737,7 +4737,7 @@ q2 who aim to injure me!
 \q2 with honey from the rock to their hearts’ content.”
 
 \c 82
-\d
+\d An Asaphite song.
 \q
 \v 1 God stands out in the council of the gods,
 \q2 among the gods he rules supreme.
@@ -6651,7 +6651,7 @@ q2 who aim to injure me!
 \v 3 splendid and glorious are his deeds,
 \q2 his victories know no end;
 \q
-\v 3 he will have us celebrate his wondrous deeds,
+\v 4 he will have us celebrate his wondrous deeds,
 \q2 for the Eternal is gracious and pitiful.
 \q
 \v 5 He feeds his worshippers;
@@ -6818,7 +6818,8 @@ q2 who aim to injure me!
 \q
 \v 17 The dead cannot praise the Eternal,
 \q2 nor any who sink to the silent land;
-\q2 but we bless the Eternal now and evermore.
+\q2 
+\v 18 but we bless the Eternal now and evermore.
 
 \c 116
 \qc
@@ -6917,7 +6918,8 @@ q2 who aim to injure me!
 \q2 so shall I feast mine eyes on my defeated foes.
 \q
 \v 8 Far better rely on the Eternal than put faith in men;
-\q2 far better rely on the Eternal than put faith in princes.
+\q2 
+\v 9 far better rely on the Eternal than put faith in princes.
 \q
 \v 10 The pagans all swarmed around me;
 \q2 I routed them, relying on the Eternal.
@@ -7228,7 +7230,8 @@ q2 who aim to injure me!
 \v 113 I hate men who are half and half, I love thy law;
 \q2
 \v 114 I await thy promise, thou my shield and shelter.
-\q2 Begone, you villains, let me keep my God’s commands!
+\q2 
+\v 115 Begone, you villains, let me keep my God’s commands!
 \q
 \v 116 Uphold me, as thou hast promised, disappoint not my hope, but let me live;
 \q2
@@ -7542,7 +7545,8 @@ q2 who aim to injure me!
 \q
 \v 5 The Eternal will send you a blessing from Sion;
 \q2 you shall see Jerusalem flourish all your days,
-\q2 you shall live to see your children’s children.
+\q2 
+\v 6 you shall live to see your children’s children.
 \q2 [[May Israel prosper!]]
 
 \c 129
@@ -7577,7 +7581,8 @@ q2 who aim to injure me!
 \d A pilgrim song.
 \q
 \v 1 Out of the depths I call to thee, O thou Eternal;
-\q2 Lord, listen to my cry,
+\q2 
+\v 2 Lord, listen to my cry,
 \q2 let thine ears heed my entreaty.
 \q
 \v 3 If thou didst keep strict tally of sins,
@@ -7597,7 +7602,7 @@ q2 who aim to injure me!
 \q2 for with the Eternal there is love,
 \q2 there is a wealth of saving power;
 \q
-\v ’tis he who shall save Israel
+\v 8 ’tis he who shall save Israel
 \q2 from all their sins.
 
 \c 131
@@ -7891,7 +7896,7 @@ q2 who aim to injure me!
 \q2 with courage to inspire my soul!
 \b
 \q
-V 4 When kings on earth hear of thy mind and methods,
+\v 4 When kings on earth hear of thy mind and methods,
 \q2 they shall all praise thee, O Eternal One,
 \q2
 \v 5 and sing thy providence;
@@ -8158,7 +8163,7 @@ V 4 When kings on earth hear of thy mind and methods,
 \q guide me by thy good Spirit
 \q2 on a straight road;
 \q
-\v O thou Eternal, as thou art thyself, revive me,
+\v 11 O thou Eternal, as thou art thyself, revive me,
 \q2 as thou art faithful, bring me out of trouble;
 \q
 \v 12 in love to me, wipe out my foes,
@@ -8293,7 +8298,8 @@ V 4 When kings on earth hear of thy mind and methods,
 \qc
 \v 1 Hallelujah.
 \q Praise the Eternal, O my soul!
-\q2 As long as I live, I will praise the Eternal,
+\q2 
+\v 2 As long as I live, I will praise the Eternal,
 \q2 and sing to my God, as long as I survive.
 \q
 \v 3 Rely not upon great men–
@@ -8384,10 +8390,10 @@ V 4 When kings on earth hear of thy mind and methods,
 \v 16 showering snow white as wool,
 \q2 scattering hoarfrost thick as ashes,
 \q2
-\v 16 casting hailstones down like crumbs.
+\v 17 casting hailstones down like crumbs.
 \q The waters freeze;
 \q2
-\v 17 he sends an order, and they melt;
+\v 18 he sends an order, and they melt;
 \q once he makes the wind blow,
 \q2 then the waters flow.
 \q


### PR DESCRIPTION
Fixed transcription mistakes in Ps 76-150 revealed by 'Chapter/Verse Numbers' and 'Markers' basic checks
Hi Peter, I've gone through the list you sent and corrected a number of transcription errors which I had made. The only outstanding issue is duplicated verse numbering in Ps 139:14, which follows how Moffatt has numbered it. 

![image](https://github.com/prust/usfm-bibles/assets/163934522/c4b48146-6cc1-4f64-bd21-2ff244a8b44b)
